### PR TITLE
Update for Rimworld [1.0] + quality of life updates

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,31 +1,33 @@
 {
     "mod_name": "Example Mod",
+    "mod_folder": "{{cookiecutter.mod_name|replace(' ','_')}}",
     "author": "MySteamUsername",
     "in_game_description": "A short mod description.",
-    "mod_ver": "1.0.0",
+    "mod_ver": ["1.0.0","0.19.0","0.18.0"],
 	"create_empty_definitions": "n",
     "rw64": "n",
+    "githubURL": " ",
 	
 	"_visual_studio": {
         "mod_name": {
             "label": "Mod name (see tooltip)",
-            "description": "The name of your mod (cannot easily change later) (must Create To folder of same name in \\Rimworld\\Mods\\)",
-			"selector": "string"
+            "description": "The name of your mod (cannot easily change later) (must Create To folder of same name in \\Rimworld\\Mods\\)"
+        },
+        "mod_folder": {
+            "label": "Mod folder",
+            "description": "The root folder for your mod. Defaults to({{cookiecutter.mod_name|replace(' ','_')}})"
         },
         "author": {
             "label": "Author",
-            "description": "Use your Steam username for automatic linking of mod to profile (can change later in About-Release.xml)",
-			"selector": "string"
+            "description": "Use your Steam username for automatic linking of mod to profile (can change later in About-Release.xml)"
         },
         "in_game_description" : {
             "label": "Mod Description",
-            "description": "The description of the mod as it appears in-game (can change later in About-Release.xml)",
-            "selector": "string"
+            "description": "The description of the mod as it appears in-game (can change later in About-Release.xml)"
         },
         "mod_ver" : {
             "label": "Mod Version",
-            "description": "The version of Rimworld this mod is for (default:1.0.0)",
-            "selector": "string"
+            "description": "The version of Rimworld this mod is for (default:1.0.0)"
         },
         "create_empty_definitions": {
             "label": "Create blank XML definition files",
@@ -34,12 +36,11 @@
         },
         "rw64": {
             "label": "RimWorldWin64.exe ?",
-            "description": "Are you using RimWorldWin64.exe or not to launch",
+            "description": "Are you using RimWorldWin64.exe or not to develop?",
             "selector": "yesno"
         },
         "githubURL": {
             "label": "Github",
-            "selector": "none",
             "url": "https://github.com/n-fisher/cookiecutter-rimworld-mod-development/blob/master/README.md"
         }
     }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -40,6 +40,7 @@
         },
         "githubURL": {
             "label": "Github",
+            "selector": "none",
             "url": "https://github.com/n-fisher/cookiecutter-rimworld-mod-development/blob/master/README.md"
         }
     }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "mod_name": "Example Mod",
-    "mod_folder": "{{cookiecutter.mod_name|replace(' ','_')}}",
+    "mod_folder": " ",
     "author": "MySteamUsername",
     "in_game_description": "A short mod description.",
     "mod_ver": ["1.0.0","0.19.0","0.18.0"],
@@ -10,12 +10,12 @@
 	
 	"_visual_studio": {
         "mod_name": {
-            "label": "Mod name (see tooltip)",
-            "description": "The name of your mod (cannot easily change later) (must Create To folder of same name in \\Rimworld\\Mods\\)"
+            "label": "Mod name",
+            "description": "The name of your mod (cannot easily change later)"
         },
         "mod_folder": {
             "label": "Mod folder",
-            "description": "The root folder for your mod. Defaults to({{cookiecutter.mod_name|replace(' ','_')}})"
+            "description": "The root folder for your mod."
         },
         "author": {
             "label": "Author",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,6 +4,7 @@
     "in_game_description": "A short mod description.",
     "mod_ver": "1.0.0",
 	"create_empty_definitions": "n",
+    "rw64": "n",
 	
 	"_visual_studio": {
         "mod_name": {
@@ -34,7 +35,13 @@
             "label": "Create blank XML definition files",
             "description": "Create empty files as templates for your definitions (delete all the rest!)",
 			"selector": "yesno",
-			"url": "https://github.com/n-fisher/cookiecutter-rimworld-mod-development/blob/master/README.md"
+			"url": "https://github.com/n-fisher/cookiecutter-rimworld-mod-development/blob/master/README.md"       
+        },
+        "rw64":{
+            "label": "RimWorldWin64.exe ?",
+            "description": "Are you using RimWorldWin64.exe or not to launch",
+            "selector": "yesno",
+            "url": "https://github.com/n-fisher/cookiecutter-rimworld-mod-development/blob/master/README.md"
         }
     }
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,38 +5,38 @@
     "mod_ver": "1.0.0",
 	"create_empty_definitions": "n",
     "rw64": "n",
-    "githubURL": "",
+    "githubURL": "https://github.com/n-fisher/cookiecutter-rimworld-mod-development/blob/master/README.md",
 	
 	"_visual_studio": {
         "mod_name": {
             "label": "Mod name (see tooltip)",
             "description": "The name of your mod (cannot easily change later) (must Create To folder of same name in \\Rimworld\\Mods\\)",
-			"selector": "string",
+			"selector": "string"
         },
         "author": {
             "label": "Author",
             "description": "Use your Steam username for automatic linking of mod to profile (can change later in About-Release.xml)",
-			"selector": "string",
+			"selector": "string"
         },
         "in_game_description" : {
             "label": "Mod Description",
             "description": "The description of the mod as it appears in-game (can change later in About-Release.xml)",
-            "selector": "string",
+            "selector": "string"
         },
         "mod_ver" : {
             "label": "Mod Version",
             "description": "The version of Rimworld this mod is for (default:1.0.0)",
-            "selector": "string",
+            "selector": "string"
         },
         "create_empty_definitions": {
             "label": "Create blank XML definition files",
             "description": "Create empty files as templates for your definitions (delete all the rest!)",
-			"selector": "yesno",     
+			"selector": "yesno"
         },
         "rw64": {
             "label": "RimWorldWin64.exe ?",
             "description": "Are you using RimWorldWin64.exe or not to launch",
-            "selector": "yesno",
+            "selector": "yesno"
         },
         "githubURL": {
             "label": "Github",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -2,6 +2,7 @@
     "mod_name": "Example Mod",
     "author": "MySteamUsername",
     "in_game_description": "A short mod description.",
+    "mod_ver": "1.0.0",
 	"create_empty_definitions": "n",
 	
 	"_visual_studio": {
@@ -20,6 +21,12 @@
         "in_game_description" : {
             "label": "Mod Description",
             "description": "The description of the mod as it appears in-game (can change later in About-Release.xml)",
+            "selector": "string",
+            "url": "https://github.com/n-fisher/cookiecutter-rimworld-mod-development/blob/master/README.md"
+        },
+        "mod_ver" : {
+            "label": "Mod Version",
+            "description": "The version of Rimworld this mod is for (default:1.0.0)",
             "selector": "string",
             "url": "https://github.com/n-fisher/cookiecutter-rimworld-mod-development/blob/master/README.md"
         },

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,7 +5,6 @@
     "mod_ver": "1.0.0",
 	"create_empty_definitions": "n",
     "rw64": "n",
-    "githubURL": "https://github.com/n-fisher/cookiecutter-rimworld-mod-development/blob/master/README.md",
 	
 	"_visual_studio": {
         "mod_name": {

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,42 +5,41 @@
     "mod_ver": "1.0.0",
 	"create_empty_definitions": "n",
     "rw64": "n",
+    "githubURL": "",
 	
 	"_visual_studio": {
         "mod_name": {
             "label": "Mod name (see tooltip)",
             "description": "The name of your mod (cannot easily change later) (must Create To folder of same name in \\Rimworld\\Mods\\)",
 			"selector": "string",
-			"url": "https://github.com/n-fisher/cookiecutter-rimworld-mod-development/blob/master/README.md"
         },
         "author": {
             "label": "Author",
             "description": "Use your Steam username for automatic linking of mod to profile (can change later in About-Release.xml)",
 			"selector": "string",
-            "url": "https://github.com/n-fisher/cookiecutter-rimworld-mod-development/blob/master/README.md"
         },
         "in_game_description" : {
             "label": "Mod Description",
             "description": "The description of the mod as it appears in-game (can change later in About-Release.xml)",
             "selector": "string",
-            "url": "https://github.com/n-fisher/cookiecutter-rimworld-mod-development/blob/master/README.md"
         },
         "mod_ver" : {
             "label": "Mod Version",
             "description": "The version of Rimworld this mod is for (default:1.0.0)",
             "selector": "string",
-            "url": "https://github.com/n-fisher/cookiecutter-rimworld-mod-development/blob/master/README.md"
         },
         "create_empty_definitions": {
             "label": "Create blank XML definition files",
             "description": "Create empty files as templates for your definitions (delete all the rest!)",
-			"selector": "yesno",
-			"url": "https://github.com/n-fisher/cookiecutter-rimworld-mod-development/blob/master/README.md"       
+			"selector": "yesno",     
         },
-        "rw64":{
+        "rw64": {
             "label": "RimWorldWin64.exe ?",
             "description": "Are you using RimWorldWin64.exe or not to launch",
             "selector": "yesno",
+        },
+        "githubURL": {
+            "label": "Github",
             "url": "https://github.com/n-fisher/cookiecutter-rimworld-mod-development/blob/master/README.md"
         }
     }

--- a/{{cookiecutter.mod_name}}/About/About-Debug.xml
+++ b/{{cookiecutter.mod_name}}/About/About-Debug.xml
@@ -2,7 +2,7 @@
 <ModMetaData>
 	<name>{{cookiecutter.mod_name}} - Dev Build</name>
 	<author>{{cookiecutter.author}}</author>
-	<targetVersion>0.18.0</targetVersion>
+	<targetVersion>{{cookiecutter.mod_ver}}</targetVersion>
 	<description>{{cookiecutter.in_game_description}} 
 (This is the dev version of {{cookiecutter.mod_name}}. The release version of About.xml is available for editing at About/About-Release.xml. Edits made on this file or on the temporary About/About.xml won't show up on the release version. Use VisualStudio to build a "Release" version of this mod when ready to upload your mod!)</description>
 	<url>https://steamcommunity.com/id/{{cookiecutter.author}}/myworkshopfiles/?appid=294100</url>

--- a/{{cookiecutter.mod_name}}/About/About-Release.xml
+++ b/{{cookiecutter.mod_name}}/About/About-Release.xml
@@ -2,7 +2,7 @@
 <ModMetaData>
 	<name>{{cookiecutter.mod_name}}</name>
 	<author>{{cookiecutter.author}}</author>
-	<targetVersion>0.18.0</targetVersion>
+	<targetVersion>{{cookiecutter.mod_ver}}</targetVersion>
 	<description>{{cookiecutter.in_game_description}}</description>
 	<url>https://steamcommunity.com/id/{{cookiecutter.author}}/myworkshopfiles/?appid=294100</url>
 </ModMetaData>

--- a/{{cookiecutter.mod_name}}/Source/{{cookiecutter.mod_name.replace(' ', '_')}}.csproj
+++ b/{{cookiecutter.mod_name}}/Source/{{cookiecutter.mod_name.replace(' ', '_')}}.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\RimWorldWin_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\RimWorldWin{%if(cookiecutter.rw64 != 'n')%}64{%endif%}_Data\Managed\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -41,7 +41,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\RimWorldWin_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\RimWorldWin{%if(cookiecutter.rw64 != 'n')%}64{%endif%}_Data\Managed\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
 	<None Include="..\About\**" />

--- a/{{cookiecutter.mod_name}}/Source/{{cookiecutter.mod_name.replace(' ', '_')}}.csproj
+++ b/{{cookiecutter.mod_name}}/Source/{{cookiecutter.mod_name.replace(' ', '_')}}.csproj
@@ -7,12 +7,13 @@
     <ProjectGuid>{D7D21B4A-1DA7-41D8-B202-C58CA8FA62AA}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>{{cookiecutter.mod_folder}}</RootNamespace>
-    <AssemblyName>{{cookiecutter.mod_folder}}</AssemblyName>
+    <RootNamespace>{{cookiecutter.mod_name.replace(' ', '_')}}</RootNamespace>
+    <AssemblyName>{{cookiecutter.mod_name.replace(' ', '_')}}</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <StartArguments>-quicktest</StartArguments>
     <DebugSymbols>false</DebugSymbols>
     <DebugType>none</DebugType>
     <Optimize>false</Optimize>
@@ -60,7 +61,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <StartAction>Program</StartAction>
-    <StartProgram>"$(SolutionDir)..\..\RimWorldWin{%if(cookiecutter.rw64 != 'n')%}64{%endif%}.exe"</StartProgram>
+    <StartProgram>$(SolutionDir)..\..\RimWorldWin{%if(cookiecutter.rw64 != 'n')%}64{%endif%}.exe</StartProgram>
   </PropertyGroup>
   <PropertyGroup>
     <PostBuildEvent>echo F|xcopy "$(ProjectDir)..\About\About-$(ConfigurationName).xml" "$(TargetDir)..\About\About.xml" /C /Y /K /Q /D

--- a/{{cookiecutter.mod_name}}/Source/{{cookiecutter.mod_name.replace(' ', '_')}}.csproj
+++ b/{{cookiecutter.mod_name}}/Source/{{cookiecutter.mod_name.replace(' ', '_')}}.csproj
@@ -13,7 +13,6 @@
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <StartArguments>-quicktest</StartArguments>
     <DebugSymbols>false</DebugSymbols>
     <DebugType>none</DebugType>
     <Optimize>false</Optimize>
@@ -62,6 +61,12 @@
   <PropertyGroup>
     <StartAction>Program</StartAction>
     <StartProgram>$(SolutionDir)..\..\RimWorldWin{%if(cookiecutter.rw64 != 'n')%}64{%endif%}.exe</StartProgram>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug -quicktest|AnyCPU' ">
+      <StartArguments>-quicktest</StartArguments>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release -quicktest|AnyCPU' ">
+      <StartArguments>-quicktest</StartArguments>
   </PropertyGroup>
   <PropertyGroup>
     <PostBuildEvent>echo F|xcopy "$(ProjectDir)..\About\About-$(ConfigurationName).xml" "$(TargetDir)..\About\About.xml" /C /Y /K /Q /D

--- a/{{cookiecutter.mod_name}}/Source/{{cookiecutter.mod_name.replace(' ', '_')}}.csproj
+++ b/{{cookiecutter.mod_name}}/Source/{{cookiecutter.mod_name.replace(' ', '_')}}.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{D7D21B4A-1DA7-41D8-B202-C58CA8FA62AA}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>{{cookiecutter.mod_name.replace(' ', '_')}}</RootNamespace>
-    <AssemblyName>{{cookiecutter.mod_name.replace(' ', '_')}}</AssemblyName>
+    <RootNamespace>{{cookiecutter.mod_folder}}</RootNamespace>
+    <AssemblyName>{{cookiecutter.mod_folder}}</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -24,7 +24,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\{{cookiecutter.mod_name.replace(' ', '_')}} - Release\Assemblies\</OutputPath>
+    <OutputPath>..\..\{{cookiecutter.mod_folder}} - Release\Assemblies\</OutputPath>
     <DefineConstants></DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -60,7 +60,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <StartAction>Program</StartAction>
-    <StartProgram>"$(SolutionDir)..\..\RimWorldWin{%if(cookiecutter.rw64 != 'n')%}64{%endif%}.exe -quicktest"</StartProgram>
+    <StartProgram>"$(SolutionDir)..\..\RimWorldWin{%if(cookiecutter.rw64 != 'n')%}64{%endif%}.exe"</StartProgram>
   </PropertyGroup>
   <PropertyGroup>
     <PostBuildEvent>echo F|xcopy "$(ProjectDir)..\About\About-$(ConfigurationName).xml" "$(TargetDir)..\About\About.xml" /C /Y /K /Q /D

--- a/{{cookiecutter.mod_name}}/Source/{{cookiecutter.mod_name.replace(' ', '_')}}.csproj
+++ b/{{cookiecutter.mod_name}}/Source/{{cookiecutter.mod_name.replace(' ', '_')}}.csproj
@@ -60,7 +60,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <StartAction>Program</StartAction>
-    <StartProgram>"$(SolutionDir)..\..\RimWorldWin{%if(cookiecutter.rw64 != 'n')}64{%endif%}.exe -quicktest"</StartProgram>
+    <StartProgram>"$(SolutionDir)..\..\RimWorldWin{%if(cookiecutter.rw64 != 'n')%}64{%endif%}.exe -quicktest"</StartProgram>
   </PropertyGroup>
   <PropertyGroup>
     <PostBuildEvent>echo F|xcopy "$(ProjectDir)..\About\About-$(ConfigurationName).xml" "$(TargetDir)..\About\About.xml" /C /Y /K /Q /D

--- a/{{cookiecutter.mod_name}}/Source/{{cookiecutter.mod_name.replace(' ', '_')}}.csproj
+++ b/{{cookiecutter.mod_name}}/Source/{{cookiecutter.mod_name.replace(' ', '_')}}.csproj
@@ -60,7 +60,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <StartAction>Program</StartAction>
-    <StartProgram>$(SolutionDir)..\..\RimWorldWin.exe</StartProgram>
+    <StartProgram>"$(SolutionDir)..\..\RimWorldWin{%if(cookiecutter.rw64 != 'n')}64{%endif%}.exe -quicktest"</StartProgram>
   </PropertyGroup>
   <PropertyGroup>
     <PostBuildEvent>echo F|xcopy "$(ProjectDir)..\About\About-$(ConfigurationName).xml" "$(TargetDir)..\About\About.xml" /C /Y /K /Q /D

--- a/{{cookiecutter.mod_name}}/{{cookiecutter.mod_name.replace(' ', '_')}}.sln
+++ b/{{cookiecutter.mod_name}}/{{cookiecutter.mod_name.replace(' ', '_')}}.sln
@@ -7,16 +7,20 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "{{cookiecutter.mod_name.rep
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug -quicktest|Any CPU = Debug -quicktest|Any CPU
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		Release -quicktest|Any CPU = Release -quicktest|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D7D21B4A-1DA7-41D8-B202-C58CA8FA62AA}.Debug -quicktest|Any CPU.ActiveCfg = Debug -quicktest|Any CPU
+		{D7D21B4A-1DA7-41D8-B202-C58CA8FA62AA}.Debug -quicktest|Any CPU.Build.0 = Debug -quicktest|Any CPU
 		{D7D21B4A-1DA7-41D8-B202-C58CA8FA62AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D7D21B4A-1DA7-41D8-B202-C58CA8FA62AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D7D21B4A-1DA7-41D8-B202-C58CA8FA62AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D7D21B4A-1DA7-41D8-B202-C58CA8FA62AA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DE5B7748-333A-428F-BCA9-4DB67FB289A3}.Debug|Any CPU.ActiveCfg = Release|x86
-		{DE5B7748-333A-428F-BCA9-4DB67FB289A3}.Release|Any CPU.ActiveCfg = Release|x86
+		{D7D21B4A-1DA7-41D8-B202-C58CA8FA62AA}.Release -quicktest|Any CPU.ActiveCfg = Release -quicktest|Any CPU
+		{D7D21B4A-1DA7-41D8-B202-C58CA8FA62AA}.Release -quicktest|Any CPU.Build.0 = Release -quicktest|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
I apologize for the number of commits in this,  but it took me far too long to figure out how to work on cookiecutter without sending a git push.

Anyways, this push does the following:

- adds mod version list with latest[1.0.0](as of push) being set as default
- selector for `RimWorld64.exe`
- adds ability to use `-quicktest` flag when debugging or on release testing
- Separate field for github link (not used other than display this cookiecutter github)